### PR TITLE
Fix #79 - Yellow filter buttons cover the green 'vanilla' buttons when an opportunity is scrolled.

### DIFF
--- a/CRMS Extension/scripts/content.js
+++ b/CRMS Extension/scripts/content.js
@@ -3242,6 +3242,7 @@ if (detailView){
     let newElement = document.createElement('div');
     newElement.classList.add("row");
     newElement.classList.add("sticky");
+	newElement.classList.add("helper-control-panel-parent");
     // Insert `newElement` after `referenceElement`
     titleRow.insertAdjacentElement('afterend', newElement);
 

--- a/CRMS Extension/style.css
+++ b/CRMS Extension/style.css
@@ -287,6 +287,20 @@ div.float-right{
   padding-left: 15px;
 }
 
+.helper-control-panel-parent{
+  position: sticky;
+  top: 90px !important;
+}
+
+.quick-function-section{
+	position: absolute;
+	top: 126px !important;
+}
+
+#opportunity_item_header_sticky{
+	top: 300px !important;
+}
+
 .quantity-column{
   display: table-cell !important;
 }


### PR DESCRIPTION
I've had a go at fixing the yellow buttons covering the 'vanilla' green buttons.

I've little experience of javascript & this is my first use of github too, so do let me know if I need to do anything differently.

Joe